### PR TITLE
Handle .lsc files with multiple pairs of DNs and CAs

### DIFF
--- a/bin/vomses-crosscheck
+++ b/bin/vomses-crosscheck
@@ -52,7 +52,14 @@ def get_vomses():
 def get_lsc(entry):
     path = os.path.join(vomsdir, entry.lsc)
     if os.path.exists(path):
-        return lsc_entry(line.rstrip() for line in open(path))
+        lsc_entries = []
+        fh = open(path)
+        for line in fh:
+            # Read lines two at a time
+            dn_line = line.rstrip()
+            ca_line = fh.next().rstrip()
+            lsc_entries.append(lsc_entry((dn_line, ca_line)))
+        return lsc_entries
     else:
         return None
 
@@ -63,15 +70,18 @@ missing_vomses_entries = []
 dn_mismatches          = []
 
 for entry in vomses_entries:
-    lsc = get_lsc(entry)
-    if lsc is None:
+    lsc_entries = get_lsc(entry)
+    if lsc_entries is None:
         missing_lsc_files += ["Missing lsc file: %s" % entry.lsc]
-    elif entry.dn != lsc.dn:
-        dn_mismatches += [
-            "DNs don't match for %s:" % entry.lsc,
-            "  vomses: %s" % entry.dn,
-            "     lsc: %s" % lsc.dn
-        ]
+    else:
+        lsc_dns = [lsc.dn for lsc in lsc_entries]
+        if entry.dn not in lsc_dns:
+            dn_mismatches += [
+                "DNs don't match for %s:" % entry.lsc,
+                "  vomses: %s" % entry.dn,
+                "     lsc: %s" % "\n" \
+                "          ".join(lsc_dns)
+            ]
 
 vomses_lsc_files = set(entry.lsc for entry in vomses_entries)
 

--- a/bin/vomses-crosscheck
+++ b/bin/vomses-crosscheck
@@ -5,6 +5,8 @@ import os
 import glob
 import sys
 
+MALFORMED = "malformed"
+
 vomses_path = "vomses"
 vomsdir     = "vomsdir"
 
@@ -54,12 +56,16 @@ def get_lsc(entry):
     if os.path.exists(path):
         lsc_entries = []
         fh = open(path)
-        for line in fh:
-            # Read lines two at a time
-            dn_line = line.rstrip()
-            ca_line = fh.next().rstrip()
-            lsc_entries.append(lsc_entry((dn_line, ca_line)))
-        return lsc_entries
+        try:
+            for line in fh:
+                # Read lines two at a time
+                dn_line = line.rstrip()
+                ca_line = fh.next().rstrip()
+                lsc_entries.append(lsc_entry((dn_line, ca_line)))
+            return lsc_entries
+        except StopIteration:
+            # odd number of lines
+            return MALFORMED
     else:
         return None
 
@@ -68,11 +74,15 @@ vomses_entries = get_vomses()
 missing_lsc_files      = []
 missing_vomses_entries = []
 dn_mismatches          = []
+# We can get duplicates of malformed .lsc files
+malformed_lsc_files    = set()
 
 for entry in vomses_entries:
     lsc_entries = get_lsc(entry)
     if lsc_entries is None:
         missing_lsc_files += ["Missing lsc file: %s" % entry.lsc]
+    elif lsc_entries is MALFORMED:
+        malformed_lsc_files.add("Malformed lsc file (incomplete DN/CA pair): %s" % entry.lsc)
     else:
         lsc_dns = [lsc.dn for lsc in lsc_entries]
         if entry.dn not in lsc_dns:
@@ -90,7 +100,7 @@ for lsc_path in sorted(glob.glob("*/*.lsc")):
     if lsc_path not in vomses_lsc_files:
         missing_vomses_entries += ["No vomses entry for %s" % lsc_path]
 
-for x in (missing_lsc_files, missing_vomses_entries, dn_mismatches):
+for x in (missing_lsc_files, malformed_lsc_files, missing_vomses_entries, dn_mismatches):
     if x:
         for line in x:
             print line


### PR DESCRIPTION
For SOFTWARE-2445. The `vomses-crosscheck` script now needs to handle cases where a single VOMS server has multiple DNs. These look like additional pairs of DN and CA in the .lsc file. For each entry in the vomses file, ensure that at least one of the DN and CA pairs in the corresponding .lsc file matches.

Detect malformed .lsc files - these are files with an odd number of lines, which are missing one half of the pair.

Limitation: it is possible to have extra pairs in an .lsc file that have no corresponding vomses entries. This is currently not detected.