### PR TITLE
remove multi-cert lsc files

### DIFF
--- a/bin/vomses-crosscheck
+++ b/bin/vomses-crosscheck
@@ -5,8 +5,6 @@ import os
 import glob
 import sys
 
-MALFORMED = "malformed"
-
 vomses_path = "vomses"
 vomsdir     = "vomsdir"
 
@@ -56,16 +54,12 @@ def get_lsc(entry):
     if os.path.exists(path):
         lsc_entries = []
         fh = open(path)
-        try:
-            for line in fh:
-                # Read lines two at a time
-                dn_line = line.rstrip()
-                ca_line = fh.next().rstrip()
-                lsc_entries.append(lsc_entry((dn_line, ca_line)))
-            return lsc_entries
-        except StopIteration:
-            # odd number of lines
-            return MALFORMED
+        for line in fh:
+            # Read lines two at a time
+            dn_line = line.rstrip()
+            ca_line = fh.next().rstrip()
+            lsc_entries.append(lsc_entry((dn_line, ca_line)))
+        return lsc_entries
     else:
         return None
 
@@ -74,15 +68,11 @@ vomses_entries = get_vomses()
 missing_lsc_files      = []
 missing_vomses_entries = []
 dn_mismatches          = []
-# We can get duplicates of malformed .lsc files
-malformed_lsc_files    = set()
 
 for entry in vomses_entries:
     lsc_entries = get_lsc(entry)
     if lsc_entries is None:
         missing_lsc_files += ["Missing lsc file: %s" % entry.lsc]
-    elif lsc_entries is MALFORMED:
-        malformed_lsc_files.add("Malformed lsc file (incomplete DN/CA pair): %s" % entry.lsc)
     else:
         lsc_dns = [lsc.dn for lsc in lsc_entries]
         if entry.dn not in lsc_dns:
@@ -100,7 +90,7 @@ for lsc_path in sorted(glob.glob("*/*.lsc")):
     if lsc_path not in vomses_lsc_files:
         missing_vomses_entries += ["No vomses entry for %s" % lsc_path]
 
-for x in (missing_lsc_files, malformed_lsc_files, missing_vomses_entries, dn_mismatches):
+for x in (missing_lsc_files, missing_vomses_entries, dn_mismatches):
     if x:
         for line in x:
             print line

--- a/bin/vomses-crosscheck
+++ b/bin/vomses-crosscheck
@@ -52,14 +52,7 @@ def get_vomses():
 def get_lsc(entry):
     path = os.path.join(vomsdir, entry.lsc)
     if os.path.exists(path):
-        lsc_entries = []
-        fh = open(path)
-        for line in fh:
-            # Read lines two at a time
-            dn_line = line.rstrip()
-            ca_line = fh.next().rstrip()
-            lsc_entries.append(lsc_entry((dn_line, ca_line)))
-        return lsc_entries
+        return lsc_entry(line.rstrip() for line in open(path))
     else:
         return None
 
@@ -70,18 +63,15 @@ missing_vomses_entries = []
 dn_mismatches          = []
 
 for entry in vomses_entries:
-    lsc_entries = get_lsc(entry)
-    if lsc_entries is None:
+    lsc = get_lsc(entry)
+    if lsc is None:
         missing_lsc_files += ["Missing lsc file: %s" % entry.lsc]
-    else:
-        lsc_dns = [lsc.dn for lsc in lsc_entries]
-        if entry.dn not in lsc_dns:
-            dn_mismatches += [
-                "DNs don't match for %s:" % entry.lsc,
-                "  vomses: %s" % entry.dn,
-                "     lsc: %s" % "\n" \
-                "          ".join(lsc_dns)
-            ]
+    elif entry.dn != lsc.dn:
+        dn_mismatches += [
+            "DNs don't match for %s:" % entry.lsc,
+            "  vomses: %s" % entry.dn,
+            "     lsc: %s" % lsc.dn
+        ]
 
 vomses_lsc_files = set(entry.lsc for entry in vomses_entries)
 

--- a/vomsdir/miniclean/voms.hep.pnnl.gov.lsc
+++ b/vomsdir/miniclean/voms.hep.pnnl.gov.lsc
@@ -1,4 +1,2 @@
 /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov
 /DC=com/DC=DigiCert-Grid/O=DigiCert Grid/CN=DigiCert Grid CA-1 G2
-/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov
-/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1

--- a/vomsdir/project8/voms.hep.pnnl.gov.lsc
+++ b/vomsdir/project8/voms.hep.pnnl.gov.lsc
@@ -1,4 +1,2 @@
 /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov
 /DC=com/DC=DigiCert-Grid/O=DigiCert Grid/CN=DigiCert Grid CA-1 G2
-/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov
-/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1

--- a/vomses
+++ b/vomses
@@ -55,6 +55,4 @@
 "dune" "voms2.fnal.gov" "15042" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov" "dune"
 "supercdms" "voms.slac.stanford.edu" "15001" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.slac.stanford.edu" "supercdms"
 "project8" "voms.hep.pnnl.gov" "15001" "/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov" "project8"
-"project8" "voms.hep.pnnl.gov" "15001" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov" "project8"
 "miniclean" "voms.hep.pnnl.gov" "15001" "/DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov" "miniclean"
-"miniclean" "voms.hep.pnnl.gov" "15001" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.hep.pnnl.gov" "miniclean"


### PR DESCRIPTION
It didn't work as intended with multiple voms certs in a single lsc file.

Also back out the related changes to support this from vomses-crosscheck.
