### PR TITLE
drop dependent objects from cdf, cdf1 vomsServers (SOFTWARE-2612)

### DIFF
--- a/gums.config.template
+++ b/gums.config.template
@@ -504,15 +504,6 @@
 			role='production'/>
 
 		<vomsUserGroup
-			name='cdf-cnaf'
-			access='read self'
-			description=''
-			vomsServer='cdf1'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf'/>
-
-		<vomsUserGroup
 			name='cdf-fnal'
 			access='read self'
 			description=''
@@ -520,25 +511,6 @@
 			matchFQAN='exact'
 			acceptProxyWithoutFQAN='false'
 			voGroup='/cdf'/>
-
-		<vomsUserGroup
-			name='cdf-pd'
-			access='read self'
-			description=''
-			vomsServer='cdf'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf'/>
-
-		<vomsUserGroup
-			name='cdfdev-cnaf'
-			access='read self'
-			description=''
-			vomsServer='cdf1'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='development'/>
 
 		<vomsUserGroup
 			name='cdfdev-fnal'
@@ -551,26 +523,6 @@
 			role='development'/>
 
 		<vomsUserGroup
-			name='cdfdev-pd'
-			access='read self'
-			description=''
-			vomsServer='cdf'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='development'/>
-
-		<vomsUserGroup
-			name='cdffgrid-cnaf'
-			access='read self'
-			description=''
-			vomsServer='cdf1'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='fermigrid'/>
-
-		<vomsUserGroup
 			name='cdffgrid-fnal'
 			access='read self'
 			description=''
@@ -579,26 +531,6 @@
 			acceptProxyWithoutFQAN='false'
 			voGroup='/cdf/glidecaf'
 			role='fermigrid'/>
-
-		<vomsUserGroup
-			name='cdffgrid-pd'
-			access='read self'
-			description=''
-			vomsServer='cdf'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='fermigrid'/>
-
-		<vomsUserGroup
-			name='cdfnam-cnaf'
-			access='read self'
-			description=''
-			vomsServer='cdf1'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='namcaf'/>
 
 		<vomsUserGroup
 			name='cdfnam-fnal'
@@ -611,40 +543,10 @@
 			role='namcaf'/>
 
 		<vomsUserGroup
-			name='cdfnam-pd'
-			access='read self'
-			description=''
-			vomsServer='cdf'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='namcaf'/>
-
-		<vomsUserGroup
-			name='cdftestcaf-cnaf'
-			access='read self'
-			description=''
-			vomsServer='cdf1'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='testcaf'/>
-
-		<vomsUserGroup
 			name='cdftestcaf-fnal'
 			access='read self'
 			description=''
 			vomsServer='cdf2'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/cdf/glidecaf'
-			role='testcaf'/>
-
-		<vomsUserGroup
-			name='cdftestcaf-pd'
-			access='read self'
-			description=''
-			vomsServer='cdf'
 			matchFQAN='exact'
 			acceptProxyWithoutFQAN='false'
 			voGroup='/cdf/glidecaf'
@@ -1575,36 +1477,12 @@
 			accountMappers='bellepro'/>
 
 		<groupToAccountMapping
-			name='cdf-cnaf'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdf-cnaf'
-			accountMappers='cdf'/>
-
-		<groupToAccountMapping
 			name='cdf-fnal'
 			description=''
 			accountingVoSubgroup='cdf'
 			accountingVo='CDF'
 			userGroups='cdf-fnal'
 			accountMappers='cdf'/>
-
-		<groupToAccountMapping
-			name='cdf-pd'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdf-pd'
-			accountMappers='cdf'/>
-
-		<groupToAccountMapping
-			name='cdfdev-cnaf'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdfdev-cnaf'
-			accountMappers='cdfdev'/>
 
 		<groupToAccountMapping
 			name='cdfdev-fnal'
@@ -1615,44 +1493,12 @@
 			accountMappers='cdfdev'/>
 
 		<groupToAccountMapping
-			name='cdfdev-pd'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdfdev-pd'
-			accountMappers='cdfdev'/>
-
-		<groupToAccountMapping
-			name='cdffgrid-cnaf'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdffgrid-cnaf'
-			accountMappers='cdffgrid'/>
-
-		<groupToAccountMapping
 			name='cdffgrid-fnal'
 			description=''
 			accountingVoSubgroup='cdf'
 			accountingVo='CDF'
 			userGroups='cdffgrid-fnal'
 			accountMappers='cdffgrid'/>
-
-		<groupToAccountMapping
-			name='cdffgrid-pd'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdffgrid-pd'
-			accountMappers='cdffgrid'/>
-
-		<groupToAccountMapping
-			name='cdfnam-cnaf'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdfnam-cnaf'
-			accountMappers='cdfnam'/>
 
 		<groupToAccountMapping
 			name='cdfnam-fnal'
@@ -1663,35 +1509,11 @@
 			accountMappers='cdfnam'/>
 
 		<groupToAccountMapping
-			name='cdfnam-pd'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdfnam-pd'
-			accountMappers='cdfnam'/>
-
-		<groupToAccountMapping
-			name='cdftestcaf-cnaf'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdftestcaf-cnaf'
-			accountMappers='cdf'/>
-
-		<groupToAccountMapping
 			name='cdftestcaf-fnal'
 			description=''
 			accountingVoSubgroup='cdf'
 			accountingVo='CDF'
 			userGroups='cdftestcaf-fnal'
-			accountMappers='cdf'/>
-
-		<groupToAccountMapping
-			name='cdftestcaf-pd'
-			description=''
-			accountingVoSubgroup='cdf'
-			accountingVo='CDF'
-			userGroups='cdftestcaf-pd'
 			accountMappers='cdf'/>
 
 		<groupToAccountMapping
@@ -2163,7 +1985,7 @@
 	<hostToGroupMappings>
 
 		<hostToGroupMapping
-			groupToAccountMappings='cdf-fnal, cdfdev-fnal, cdffgrid-fnal, cdfnam-fnal, cdftestcaf-fnal, cdf-cnaf, cdfdev-cnaf, cdffgrid-cnaf, cdfnam-cnaf, cdftestcaf-cnaf, cdf-pd, cdfdev-pd, cdffgrid-pd, cdfnam-pd, cdftestcaf-pd, fermilab, mis, star, uscmsuser, cmsuser, uscmst2admin, uscmssoft, cmssoft, uscmsprod, uscmsphedex, cmsphedex2, uscmsfrontier, cmsuser-null, cmsproduction, LIGO, dzerouser, dzeroana, dzeroservice, dosar, des, glow, nanohub, geant4, geant4-lcgadmin, osg, newUsatlasProd, newUsatlasSoft, newUsatlas, newAtlas, osgedu, ops, des-production, ilc, nysgrid, sbgrid, cigi, icecube, alice, gluex, gridunesp, hcc, belle, bellepro, suragrid, gcvo, gcedu, dream, lsst, lqcd, auger, glast.org, enmr.eu, vo.cta.in2p3.fr, xenon.biggrid.nl, snoplus.snolab.ca, LZ, dune, dune-production, duneana, dunegli, project8, project8_prod, miniclean, miniclean_prod'
+			groupToAccountMappings='cdf-fnal, cdfdev-fnal, cdffgrid-fnal, cdfnam-fnal, cdftestcaf-fnal, fermilab, mis, star, uscmsuser, cmsuser, uscmst2admin, uscmssoft, cmssoft, uscmsprod, uscmsphedex, cmsphedex2, uscmsfrontier, cmsuser-null, cmsproduction, LIGO, dzerouser, dzeroana, dzeroservice, dosar, des, glow, nanohub, geant4, geant4-lcgadmin, osg, newUsatlasProd, newUsatlasSoft, newUsatlas, newAtlas, osgedu, ops, des-production, ilc, nysgrid, sbgrid, cigi, icecube, alice, gluex, gridunesp, hcc, belle, bellepro, suragrid, gcvo, gcedu, dream, lsst, lqcd, auger, glast.org, enmr.eu, vo.cta.in2p3.fr, xenon.biggrid.nl, snoplus.snolab.ca, LZ, dune, dune-production, duneana, dunegli, project8, project8_prod, miniclean, miniclean_prod'
 			description=''
 			cn='*/?*.@DOMAINNAME@'/>
 


### PR DESCRIPTION
drop vomsUserGroup:
 - cdf-cnaf         (vomsServer: cdf1)
 - cdfdev-cnaf      (vomsServer: cdf1)
 - cdffgrid-cnaf    (vomsServer: cdf1)
 - cdfnam-cnaf      (vomsServer: cdf1)
 - cdftestcaf-cnaf  (vomsServer: cdf1)
 - cdf-pd           (vomsServer: cdf)
 - cdfdev-pd        (vomsServer: cdf)
 - cdffgrid-pd      (vomsServer: cdf)
 - cdfnam-pd        (vomsServer: cdf)
 - cdftestcaf-pd    (vomsServer: cdf)

drop groupToAccountMapping:
 - cdf-cnaf
 - cdf-pd
 - cdfdev-cnaf
 - cdfdev-pd
 - cdffgrid-cnaf
 - cdffgrid-pd
 - cdfnam-cnaf
 - cdfnam-pd
 - cdftestcaf-cnaf
 - cdftestcaf-pd

drop hostToGroupMapping:
 - cdf-cnaf
 - cdfdev-cnaf
 - cdffgrid-cnaf
 - cdfnam-cnaf
 - cdftestcaf-cnaf
 - cdf-pd
 - cdfdev-pd
 - cdffgrid-pd
 - cdfnam-pd
 - cdftestcaf-pd