### PR TITLE
Correct USATLAS mapping

### DIFF
--- a/gums.config.template
+++ b/gums.config.template
@@ -831,7 +831,7 @@
 			voGroup='/nanohub'/>
 
 		<vomsUserGroup
-			name='newUsatlasProd'
+			name='UsatlasProd'
 			access='read self'
 			description=''
 			vomsServer='atlas'
@@ -841,7 +841,7 @@
 			role='production'/>
 
 		<vomsUserGroup
-			name='newUsatlasSoft'
+			name='UsatlasSoft'
 			access='read self'
 			description=''
 			vomsServer='atlas'
@@ -851,7 +851,7 @@
 			role='software'/>
 
 		<vomsUserGroup
-			name='newatlas'
+			name='Atlas'
 			access='read self'
 			description=''
 			vomsServer='atlas'
@@ -860,7 +860,7 @@
 			voGroup='/atlas'/>
 
 		<vomsUserGroup
-			name='newusatlas'
+			name='Usatlas'
 			access='read self'
 			description=''
 			vomsServer='atlas'
@@ -1625,35 +1625,35 @@
 			accountMappers='nanohub'/>
 
 		<groupToAccountMapping
-			name='newAtlas'
+			name='Atlas'
 			description=''
 			accountingVoSubgroup='atlas'
 			accountingVo='ATLAS'
-			userGroups='newatlas'
+			userGroups='Atlas'
 			accountMappers='usatlas4'/>
 
 		<groupToAccountMapping
-			name='newUsatlas'
+			name='Usatlas'
 			description=''
 			accountingVoSubgroup='atlas'
 			accountingVo='ATLAS'
-			userGroups='newusatlas'
+			userGroups='Usatlas'
 			accountMappers='usatlas3'/>
 
 		<groupToAccountMapping
-			name='newUsatlasProd'
+			name='UsatlasProd'
 			description=''
 			accountingVoSubgroup='atlas'
 			accountingVo='ATLAS'
-			userGroups='newUsatlasProd'
+			userGroups='UsatlasProd'
 			accountMappers='usatlas1'/>
 
 		<groupToAccountMapping
-			name='newUsatlasSoft'
+			name='UsatlasSoft'
 			description=''
 			accountingVoSubgroup='atlas'
 			accountingVo='ATLAS'
-			userGroups='newUsatlasSoft'
+			userGroups='UsatlasSoft'
 			accountMappers='usatlas2'/>
 
 		<groupToAccountMapping
@@ -1749,7 +1749,7 @@
 	<hostToGroupMappings>
 
 		<hostToGroupMapping
-			groupToAccountMappings='cdf-fnal, cdfana, fermigli, fermilab, mis, star, cmspilot, uscmspilot, cmslocal, cmsproduction, cmslcgadmin, dzeroana, dosar, des, glow, nanohub, geant4, geant4-lcgadmin, osg, newUsatlasProd, newUsatlasSoft, newUsatlas, newAtlas, ops, des-production, ilc, sbgrid, cigi, icecube, alice, gluex, gridunesp, hcc, belle, bellepro, suragrid, gcvo, gcedu, dream, lsst, lqcd, auger, glast.org, enmr.eu, vo.cta.in2p3.fr, xenon.biggrid.nl, snoplus.snolab.ca, LZ, dune, dune-production, duneana, dunegli, project8, project8_prod, miniclean, miniclean_prod'
+			groupToAccountMappings='cdf-fnal, cdfana, fermigli, fermilab, mis, star, cmspilot, uscmspilot, cmslocal, cmsproduction, cmslcgadmin, dzeroana, dosar, des, glow, nanohub, geant4, geant4-lcgadmin, osg, UsatlasProd, UsatlasSoft, Usatlas, Atlas, ops, des-production, ilc, sbgrid, cigi, icecube, alice, gluex, gridunesp, hcc, belle, bellepro, suragrid, gcvo, gcedu, dream, lsst, lqcd, auger, glast.org, enmr.eu, vo.cta.in2p3.fr, xenon.biggrid.nl, snoplus.snolab.ca, LZ, dune, dune-production, duneana, dunegli, project8, project8_prod, miniclean, miniclean_prod'
 			description=''
 			cn='*/?*.@DOMAINNAME@'/>
 

--- a/gums.config.template
+++ b/gums.config.template
@@ -856,7 +856,7 @@
 			description=''
 			vomsServer='atlas'
 			matchFQAN='vo'
-			acceptProxyWithoutFQAN='true'
+			acceptProxyWithoutFQAN='false'
 			voGroup='/atlas'/>
 
 		<vomsUserGroup
@@ -864,8 +864,8 @@
 			access='read self'
 			description=''
 			vomsServer='atlas'
-			matchFQAN='vo'
-			acceptProxyWithoutFQAN='true'
+			matchFQAN='vogroup'
+			acceptProxyWithoutFQAN='false'
 			voGroup='/atlas/usatlas'/>
 
 		<vomsUserGroup

--- a/gums.config.template
+++ b/gums.config.template
@@ -419,6 +419,44 @@
 
 	<userGroups>
 
+		<vomsUserGroup
+			name='Atlas'
+			access='read self'
+			description=''
+			vomsServer='atlas'
+			matchFQAN='vo'
+			acceptProxyWithoutFQAN='false'
+			voGroup='/atlas'/>
+
+		<vomsUserGroup
+			name='Usatlas'
+			access='read self'
+			description=''
+			vomsServer='atlas'
+			matchFQAN='vogroup'
+			acceptProxyWithoutFQAN='false'
+			voGroup='/atlas/usatlas'/>
+
+		<vomsUserGroup
+			name='UsatlasProd'
+			access='read self'
+			description=''
+			vomsServer='atlas'
+			matchFQAN='exact'
+			acceptProxyWithoutFQAN='false'
+			voGroup='/atlas/usatlas'
+			role='production'/>
+
+		<vomsUserGroup
+			name='UsatlasSoft'
+			access='read self'
+			description=''
+			vomsServer='atlas'
+			matchFQAN='exact'
+			acceptProxyWithoutFQAN='false'
+			voGroup='/atlas/usatlas'
+			role='software'/>
+
 		<manualUserGroup
 			name='admins'
 			access='write'
@@ -829,44 +867,6 @@
 			matchFQAN='vo'
 			acceptProxyWithoutFQAN='true'
 			voGroup='/nanohub'/>
-
-		<vomsUserGroup
-			name='UsatlasProd'
-			access='read self'
-			description=''
-			vomsServer='atlas'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/atlas/usatlas'
-			role='production'/>
-
-		<vomsUserGroup
-			name='UsatlasSoft'
-			access='read self'
-			description=''
-			vomsServer='atlas'
-			matchFQAN='exact'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/atlas/usatlas'
-			role='software'/>
-
-		<vomsUserGroup
-			name='Atlas'
-			access='read self'
-			description=''
-			vomsServer='atlas'
-			matchFQAN='vo'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/atlas'/>
-
-		<vomsUserGroup
-			name='Usatlas'
-			access='read self'
-			description=''
-			vomsServer='atlas'
-			matchFQAN='vogroup'
-			acceptProxyWithoutFQAN='false'
-			voGroup='/atlas/usatlas'/>
 
 		<vomsUserGroup
 			name='ops'
@@ -1281,12 +1281,44 @@
 	<groupToAccountMappings>
 
 		<groupToAccountMapping
+			name='Atlas'
+			description=''
+			accountingVoSubgroup='atlas'
+			accountingVo='ATLAS'
+			userGroups='Atlas'
+			accountMappers='usatlas4'/>
+
+		<groupToAccountMapping
 			name='LZ'
 			description=''
 			accountingVoSubgroup='LZ'
 			accountingVo='LZ'
 			userGroups='voms.hep.wisc.edu'
 			accountMappers='LZ'/>
+
+		<groupToAccountMapping
+			name='Usatlas'
+			description=''
+			accountingVoSubgroup='atlas'
+			accountingVo='ATLAS'
+			userGroups='Usatlas'
+			accountMappers='usatlas3'/>
+
+		<groupToAccountMapping
+			name='UsatlasProd'
+			description=''
+			accountingVoSubgroup='atlas'
+			accountingVo='ATLAS'
+			userGroups='UsatlasProd'
+			accountMappers='usatlas1'/>
+
+		<groupToAccountMapping
+			name='UsatlasSoft'
+			description=''
+			accountingVoSubgroup='atlas'
+			accountingVo='ATLAS'
+			userGroups='UsatlasSoft'
+			accountMappers='usatlas2'/>
 
 		<groupToAccountMapping
 			name='alice'
@@ -1623,38 +1655,6 @@
 			accountingVo='NANOHUB'
 			userGroups='nanohub'
 			accountMappers='nanohub'/>
-
-		<groupToAccountMapping
-			name='Atlas'
-			description=''
-			accountingVoSubgroup='atlas'
-			accountingVo='ATLAS'
-			userGroups='Atlas'
-			accountMappers='usatlas4'/>
-
-		<groupToAccountMapping
-			name='Usatlas'
-			description=''
-			accountingVoSubgroup='atlas'
-			accountingVo='ATLAS'
-			userGroups='Usatlas'
-			accountMappers='usatlas3'/>
-
-		<groupToAccountMapping
-			name='UsatlasProd'
-			description=''
-			accountingVoSubgroup='atlas'
-			accountingVo='ATLAS'
-			userGroups='UsatlasProd'
-			accountMappers='usatlas1'/>
-
-		<groupToAccountMapping
-			name='UsatlasSoft'
-			description=''
-			accountingVoSubgroup='atlas'
-			accountingVo='ATLAS'
-			userGroups='UsatlasSoft'
-			accountMappers='usatlas2'/>
 
 		<groupToAccountMapping
 			name='ops'


### PR DESCRIPTION
Previously, the USATLAS mapping matched on `vo` - meaning that *anyone* in ATLAS would match the USATLAS rules.  This changes the matching rule to `vogroup`, meaning only those in the `/atlas/usatlas` group matches.

This commit also cleans up the group naming; after about a decade, we can just call it `atlas` and no longer `newAtlas`.