### PR TITLE
add lcluser field for project8 & miniclean (SOFTWARE-2727)

### DIFF
--- a/edg-mkgridmap.config
+++ b/edg-mkgridmap.config
@@ -126,7 +126,7 @@ group vomss://voms.hep.wisc.edu:8443/voms/lz lz
 group vomss://voms.fnal.gov:8443/voms/dune dune
 #-------------------
 #USER-VO-MAP project8 PROJECT8 -- 66 -- Malachi Schram (malachi.schram@pnnl.gov)
-group vomss://voms.hep.pnnl.gov:8443/voms/project8
+group vomss://voms.hep.pnnl.gov:8443/voms/project8 project8
 #-------------------
 #USER-VO-MAP miniclean MINICLEAN -- 67 -- Malachi Schram (malachi.schram@pnnl.gov)
-group vomss://voms.hep.pnnl.gov:8443/voms/miniclean
+group vomss://voms.hep.pnnl.gov:8443/voms/miniclean miniclean


### PR DESCRIPTION
Apparently the lcluser fields were accidentally omitted when `project8` & `miniclean` were added.