### PR TITLE
generate separate map files rather than dump to stdout

### DIFF
--- a/bin/manual-mapfile-from-gumsdb.py
+++ b/bin/manual-mapfile-from-gumsdb.py
@@ -15,9 +15,9 @@ else:
 
 xt = et.fromstring(open(gumsconfig).read())
 
-BAN_MAPFILE  = 'ban-mapfile'
-GRID_MAPFILE = 'grid-mapfile'
-VOMS_MAPFILE = 'voms-mapfile'
+BAN_MAPFILE  = 'ban-mapfile.additions'
+GRID_MAPFILE = 'grid-mapfile.additions'
+VOMS_MAPFILE = 'voms-mapfile.additions'
 
 DOC_URL = "http://opensciencegrid.github.io/" \
           "docs/security/lcmaps-voms-authentication"
@@ -92,7 +92,7 @@ host, port, dbname = re.search(r'mysql://(.*):(\d+)/(\w+)$', dburl).groups()
 
 print "Writing %s ..." % BAN_MAPFILE
 with open(BAN_MAPFILE, 'w') as f:
-    print >>f, "# /etc/grid-security/%s" % BAN_MAPFILE
+    print >>f, "# Add to /etc/grid-security/ban-mapfile"
     print >>f, "# %s/#banning-users" % DOC_URL
     print >>f
     f.flush()
@@ -101,7 +101,7 @@ with open(BAN_MAPFILE, 'w') as f:
 
 print "Writing %s ..." % GRID_MAPFILE
 with open(GRID_MAPFILE, 'w') as f:
-    print >>f, "# /etc/grid-security/%s" % GRID_MAPFILE
+    print >>f, "# Add to /etc/grid-security/grid-mapfile"
     print >>f, "# %s/#mapping-users" % DOC_URL
     print >>f
     f.flush()
@@ -322,7 +322,7 @@ custom_voms_maps = set(current_voms_maps) - set(released_voms_maps)
 if custom_voms_maps:
     print "Writing %s ..." % VOMS_MAPFILE
     with open(VOMS_MAPFILE, 'w') as f:
-        print >>f, "# /etc/grid-security/%s" % VOMS_MAPFILE
+        print >>f, "# Add to /etc/grid-security/voms-mapfile"
         print >>f, "# %s/#mapping-vos" % DOC_URL
         print >>f
         # just output never-shipped voms mappings, preserving order found in gums


### PR DESCRIPTION
I've been asked to have the manual-mapfile-from-gumsdb.py script generate separate map files rather than dump everything to stdout.

New output:

```
root@el6-gumsx ~ # ./manual-mapfile-from-gumsdb.py 
Writing ban-mapfile ...
Writing grid-mapfile ...
Writing voms-mapfile ...
root@el6-gumsx ~ # cat ban-mapfile
# /etc/grid-security/ban-mapfile
# http://opensciencegrid.github.io/docs/security/lcmaps-voms-authentication/#banning-users

"/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Alpha Flight 7727"
"/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Dancing Zorba 4528"
"/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Freddie Redonschnider 1234"
root@el6-gumsx ~ # cat grid-mapfile
# /etc/grid-security/grid-mapfile
# http://opensciencegrid.github.io/docs/security/lcmaps-voms-authentication/#mapping-users

"/DC=com/DC=example/OU=People/CN=Example User 12345" test
"/DC=org/DC=doegrids/OU=People/CN=Janet Doe 123456" osg
"/DC=org/DC=doegrids/OU=People/CN=Jane Doe 12345" osg
"/DC=com/DC=example/OU=People/CN=Example User 12345" osg
"/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Carl Edquist 1013" osg
root@el6-gumsx ~ # cat voms-mapfile
# /etc/grid-security/voms-mapfile
# http://opensciencegrid.github.io/docs/security/lcmaps-voms-authentication/#mapping-vos

"/osg/testgroup/Role=somerole/*" sam
```