### PR TITLE
add new InCommon DN/CA for voms.opensciencegrid.org (SOFTWARE-3248)

### DIFF
--- a/vomsdir/osg/voms.opensciencegrid.org.lsc
+++ b/vomsdir/osg/voms.opensciencegrid.org.lsc
@@ -1,0 +1,2 @@
+/DC=org/DC=incommon/C=US/postalCode=53706/ST=WI/L=Madison/street=1210 West Dayton Street/O=University of Wisconsin-Madison/OU=OCIS/CN=voms.opensciencegrid.org
+/C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA

--- a/vomses
+++ b/vomses
@@ -39,6 +39,7 @@
 "lsst" "voms2.fnal.gov" "15003" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov" "lsst"
 "lqcd" "voms1.fnal.gov" "15024" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms1.fnal.gov" "lqcd"
 "lqcd" "voms2.fnal.gov" "15024" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov" "lqcd"
+"osg" "voms.opensciencegrid.org" "15027" "/DC=org/DC=incommon/C=US/postalCode=53706/ST=WI/L=Madison/street=1210 West Dayton Street/O=University of Wisconsin-Madison/OU=OCIS/CN=voms.opensciencegrid.org" "osg"
 "osg" "voms1.opensciencegrid.org" "15027" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms1.opensciencegrid.org" "osg"
 "osg" "voms2.opensciencegrid.org" "15027" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.opensciencegrid.org" "osg"
 "osg" "voms.grid.iu.edu" "15027" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.grid.iu.edu" "osg"


### PR DESCRIPTION
(Note that the port is a lie, since this new VOMS server will never exist.)