### PR TITLE
drop '/*' and '/Capability=...' for grid-vorolemap (SOFTWARE-3222)

### DIFF
--- a/bin/gen-grid-vorolemap
+++ b/bin/gen-grid-vorolemap
@@ -2,6 +2,11 @@
 
 # transform existing 'voms-mapfile-default' into 'grid-vorolemap'
 
-awk 'NR==1; /^$/ {MAIN=1; print}; MAIN && NF>1 {print "\"*\"", $0}' "$@" |
+echo "# This is a grid-vomapfile intended for dCache.  For more info see:"
+echo -n "# https://www.dcache.org/manuals/Book-3.2/config/"
+echo "cf-gplazma-plug-inconfig-fhs.shtml#cf-gplazma-plug-inconfig-voauth"
+echo
+
+awk '/^$/ {MAIN=1}; MAIN && NF>1 {print "\"*\"", $0}' "$@" |
 perl -pe 's{/\*}{/}; s{/Capability=(NULL|\*)}{}'
 

--- a/bin/gen-grid-vorolemap
+++ b/bin/gen-grid-vorolemap
@@ -2,5 +2,6 @@
 
 # transform existing 'voms-mapfile-default' into 'grid-vorolemap'
 
-awk 'NR==1; /^$/ {MAIN=1; print}; MAIN && NF>1 {print "\"*\"", $0}' "$@"
+awk 'NR==1; /^$/ {MAIN=1; print}; MAIN && NF>1 {print "\"*\"", $0}' "$@" |
+perl -pe 's{/\*}{/}; s{/Capability=(NULL|\*)}{}'
 


### PR DESCRIPTION
It's either this or make a new script to generate the whole thing, which I was tempted to do, but stripping out just `/*` and `/Capability=...` is easy enough to add to this converter.