### PR TITLE
Revert "add back fnal lsst voms servers, for now (SOFTWARE-3402)"

### DIFF
--- a/vomsdir/lsst/voms1.fnal.gov.lsc
+++ b/vomsdir/lsst/voms1.fnal.gov.lsc
@@ -1,2 +1,0 @@
-/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms1.fnal.gov
-/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1

--- a/vomsdir/lsst/voms2.fnal.gov.lsc
+++ b/vomsdir/lsst/voms2.fnal.gov.lsc
@@ -1,2 +1,0 @@
-/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov
-/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1

--- a/vomses
+++ b/vomses
@@ -36,8 +36,6 @@
 "nanohub" "voms2.fnal.gov" "15022" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov" "nanohub"
 "ilc" "grid-voms.desy.de" "15110" "/C=DE/O=GermanGrid/OU=DESY/CN=host/grid-voms.desy.de" "ilc"
 "lsst" "voms.slac.stanford.edu" "15003" "/DC=org/DC=incommon/C=US/postalCode=94305/ST=CA/L=Stanford/street=450 Serra Mall/O=Stanford University/OU=SLAC/CN=voms.slac.stanford.edu" "lsst"
-"lsst" "voms1.fnal.gov" "15003" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms1.fnal.gov" "lsst"
-"lsst" "voms2.fnal.gov" "15003" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov" "lsst"
 "lqcd" "voms1.fnal.gov" "15024" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms1.fnal.gov" "lqcd"
 "lqcd" "voms2.fnal.gov" "15024" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms2.fnal.gov" "lqcd"
 "osg" "voms.opensciencegrid.org" "15027" "/DC=org/DC=incommon/C=US/postalCode=53706/ST=WI/L=Madison/street=1210 West Dayton Street/O=University of Wisconsin-Madison/OU=OCIS/CN=voms.opensciencegrid.org" "osg"


### PR DESCRIPTION
This reverts commit b1b0b6a4af1f22316fa34e5388890c5c5ebeb7b1.

Per Wei Yang, we don't want to keep the old LSST server entries for any
transition period.