### PR TITLE
Retire the CIGI VO (SOFTWARE-3598)

### DIFF
--- a/edg-mkgridmap.config
+++ b/edg-mkgridmap.config
@@ -56,9 +56,6 @@ group vomss://grid-voms.desy.de:8443/voms/ilc ilc
 # USER-VO-MAP sbgrid SBGrid -- 33 -- Ian Levesque (ian@crystal.harvard.edu)
 group vomss://hpc.sbgrid.org:8443/voms/SBGrid sbgrid
 #-------------------
-# USER-VO-MAP cigi CIGI -- 34 -- Anand Padmanabhan (apadmana@uiuc.edu)
-group vomss://vm246.roger.ncsa.illinois.edu:8443/voms/CIGI CIGI
-#-------------------
 # USER-VO-MAP icecube IceCube -- 35 -- Steve Barnet (barnet@icecube.wisc.edu)
 group vomss://grid-voms.desy.de:8443/voms/icecube icecube
 #-------------------

--- a/gums.config.template
+++ b/gums.config.template
@@ -66,16 +66,6 @@
 			sslCAFiles='/etc/grid-security/certificates/*.0'/>
 
 		<vomsServer
-			name='cigi'
-			description=''
-			persistenceFactory='mysql'
-			baseUrl='https://vm246.roger.ncsa.illinois.edu:8443/voms/CIGI'
-			sslKey='/etc/grid-security/http/httpkey.pem'
-			sslCertfile='/etc/grid-security/http/httpcert.pem'
-			sslKeyPasswd=''
-			sslCAFiles='/etc/grid-security/certificates/*.0'/>
-
-		<vomsServer
 			name='cms'
 			description=''
 			persistenceFactory='mysql'
@@ -462,15 +452,6 @@
 			acceptProxyWithoutFQAN='false'
 			voGroup='/cdf'
 			role='Analysis'/>
-
-		<vomsUserGroup
-			name='cigi'
-			access='read self'
-			description=''
-			vomsServer='cigi'
-			matchFQAN='vo'
-			acceptProxyWithoutFQAN='true'
-			voGroup='/CIGI'/>
 
 		<vomsUserGroup
 			name='cmsdefault'
@@ -906,11 +887,6 @@
 			accountName='cdfana'/>
 
 		<groupAccountMapper
-			name='cigi'
-			description=''
-			accountName='cigi'/>
-
-		<groupAccountMapper
 			name='cmsdefault'
 			description=''
 			accountName='cmsuser'/>
@@ -1221,14 +1197,6 @@
 			accountingVo='CDF'
 			userGroups='cdfana'
 			accountMappers='cdfana'/>
-
-		<groupToAccountMapping
-			name='cigi'
-			description=''
-			accountingVoSubgroup='cigi'
-			accountingVo='CIGI'
-			userGroups='cigi'
-			accountMappers='cigi'/>
 
 		<groupToAccountMapping
 			name='cmsdefault'
@@ -1563,7 +1531,7 @@
 	<hostToGroupMappings>
 
 		<hostToGroupMapping
-			groupToAccountMappings='cdf-fnal, cdfana, fermigli, fermilab, mis, star, cmspilot, uscmspilot, cmslocal, cmsproduction, cmslcgadmin, cmsdefault, dzeroana, dosar, des, glow, nanohub, geant4, ligo, osg, UsatlasProd, UsatlasLcgAdmin, UsatlasSoft, Usatlas, ops, des-production, ilc, sbgrid, cigi, icecube, alice, gluex, gridunesp, hcc, belle, bellepro, suragrid, dream, lsst, lqcd, glast.org, enmr.eu, vo.cta.in2p3.fr, xenon.biggrid.nl, snoplus.snolab.ca, LZ, dune, dune-production, duneana, dunegli'
+			groupToAccountMappings='cdf-fnal, cdfana, fermigli, fermilab, mis, star, cmspilot, uscmspilot, cmslocal, cmsproduction, cmslcgadmin, cmsdefault, dzeroana, dosar, des, glow, nanohub, geant4, ligo, osg, UsatlasProd, UsatlasLcgAdmin, UsatlasSoft, Usatlas, ops, des-production, ilc, sbgrid, icecube, alice, gluex, gridunesp, hcc, belle, bellepro, suragrid, dream, lsst, lqcd, glast.org, enmr.eu, vo.cta.in2p3.fr, xenon.biggrid.nl, snoplus.snolab.ca, LZ, dune, dune-production, duneana, dunegli'
 			description=''
 			cn='*/?*.@DOMAINNAME@'/>
 

--- a/vomsdir/CIGI/vm246.roger.ncsa.illinois.edu.lsc
+++ b/vomsdir/CIGI/vm246.roger.ncsa.illinois.edu.lsc
@@ -1,2 +1,0 @@
-/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=vm246.roger.ncsa.illinois.edu
-/DC=org/DC=cilogon/C=US/O=CILogon/CN=CILogon OSG CA 1

--- a/vomses
+++ b/vomses
@@ -10,7 +10,6 @@
 "ops" "voms2.cern.ch" "15009" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "ops"
 "ops" "lcg-voms2.cern.ch" "15009" "/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch" "ops"
 "SBGrid" "hpc.sbgrid.org" "15002" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=hpc.sbgrid.org" "SBGrid"
-"CIGI" "vm246.roger.ncsa.illinois.edu" "15001" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=vm246.roger.ncsa.illinois.edu" "CIGI"
 "mis" "voms.grid.iu.edu" "15001" "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=voms.grid.iu.edu" "mis"
 "icecube" "grid-voms.desy.de" "15109" "/C=DE/O=GermanGrid/OU=DESY/CN=host/grid-voms.desy.de" "icecube"
 "alice" "voms2.cern.ch" "15000" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "alice"


### PR DESCRIPTION
They no longer use the OSG; the VOMS cert is expired