### PR TITLE
Adding nanohub back to the VO client (SOFTWARE-3706)

### DIFF
--- a/voms-mapfile-default
+++ b/voms-mapfile-default
@@ -47,3 +47,4 @@
 "/dune/Role=Production/Capability=NULL" dunepro
 "/dune/Role=Analysis/Capability=NULL" duneana
 "/dune/Role=pilot/Capability=NULL" dunegli
+"/nanohub/*" nanohub

--- a/vomsdir/nanohub/voms.nanohub.org.lsc
+++ b/vomsdir/nanohub/voms.nanohub.org.lsc
@@ -1,0 +1,2 @@
+/DC=org/DC=incommon/C=US/ST=IN/L=West Lafayette/O=Purdue University/OU=HUBzero/CN=voms.nanohub.org
+/C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA

--- a/vomses
+++ b/vomses
@@ -45,3 +45,4 @@
 "supercdms" "voms.slac.stanford.edu" "15001" "/DC=org/DC=incommon/C=US/postalCode=94305/ST=CA/L=Stanford/street=450 Serra Mall/O=Stanford University/OU=SLAC/CN=voms.slac.stanford.edu" "supercdms"
 "dteam" "voms2.hellasgrid.gr" "15004" "/C=GR/O=HellasGrid/OU=hellasgrid.gr/CN=voms2.hellasgrid.gr" "dteam"
 "virgo" "voms.cnaf.infn.it" "15009" "/C=IT/O=INFN/OU=Host/L=CNAF/CN=voms.cnaf.infn.it" "virgo"
+"nanohub" "voms.nanohub.org" "15022" "/DC=org/DC=incommon/C=US/ST=IN/L=West Lafayette/O=Purdue University/OU=HUBzero/CN=voms.nanohub.org" "nanohub"


### PR DESCRIPTION
There was a miscommunication and we removed nanohub from the VO client