### PR TITLE
Update voms-mapfile-default

### DIFF
--- a/voms-mapfile-default
+++ b/voms-mapfile-default
@@ -6,6 +6,7 @@
 "/cdf/Role=NULL/Capability=NULL" cdf
 "/cdf/Role=Analysis/Capability=NULL" cdfana
 "/fermilab/Role=pilot/Capability=NULL" fermigli
+"/fermilab/*/Role=pilot/Capability=NULL" fermigli
 "/fermilab/*" fnalgrid
 "/star/*" star
 "/cms/Role=pilot/Capability=NULL" cmspilot


### PR DESCRIPTION
Add a line to map FQANs from Fermilab VO  subgroups to the same user as the VO-wide target.