### PR TITLE
updating the cert of gluex

### DIFF
--- a/vomsdir/Gluex/gluex.phys.uconn.edu.lsc
+++ b/vomsdir/Gluex/gluex.phys.uconn.edu.lsc
@@ -1,2 +1,2 @@
-/DC=org/DC=incommon/C=US/ST=CT/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gluex.phys.uconn.edu
+/DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gluex.phys.uconn.edu
 /C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA

--- a/vomses
+++ b/vomses
@@ -11,7 +11,7 @@
 "ops" "lcg-voms2.cern.ch" "15009" "/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch" "ops"
 "icecube" "grid-voms.desy.de" "15109" "/C=DE/O=GermanGrid/OU=DESY/CN=host/grid-voms.desy.de" "icecube"
 "alice" "voms2.cern.ch" "15000" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "alice"
-"Gluex" "gluex.phys.uconn.edu" "15014" "/DC=org/DC=incommon/C=US/ST=CT/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gluex.phys.uconn.edu" "Gluex"
+"Gluex" "gluex.phys.uconn.edu" "15014" "/DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gluex.phys.uconn.edu" "Gluex"
 "Gluex" "gryphn.phys.uconn.edu" "15014" "/DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gryphn.phys.uconn.edu" "Gluex"
 "GridUNESP" "voms.grid.unesp.br" "15000" "/C=BR/O=ANSP/OU=ANSPGrid CA/OU=Services/CN=voms.grid.unesp.br" "GridUNESP"
 "hcc" "hcc-voms.unl.edu" "15000" "/DC=org/DC=incommon/C=US/ST=Nebraska/L=Lincoln/O=University of Nebraska-Lincoln/OU=Holland Computing Center/CN=hcc-voms.unl.edu" "hcc"


### PR DESCRIPTION
We should have been done this together with gryphn since gluex is already using the new cert:

```console
openssl s_client -showcerts -servername gluex.phys.uconn.edu -connect gluex.phys.uconn.edu:15014 </dev/null
Server certificate
subject=/DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gluex.phys.uconn.edu
issuer=/C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA
```