### PR TITLE
SOFTWARE-5743 Update EIC, CLAS12, and GLOW DNs and Issuers

### DIFF
--- a/vomsdir/GLOW/voms.chtc.wisc.edu.lsc
+++ b/vomsdir/GLOW/voms.chtc.wisc.edu.lsc
@@ -1,2 +1,2 @@
-/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=voms.chtc.wisc.edu
-/C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA
+/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=voms.chtc.wisc.edu
+/C=US/O=Internet2/CN=InCommon RSA IGTF Server CA 3

--- a/vomsdir/clas12/clas12.voms2.opensciencegrid.org.lsc
+++ b/vomsdir/clas12/clas12.voms2.opensciencegrid.org.lsc
@@ -1,2 +1,2 @@
-/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=clas12.voms2.opensciencegrid.org
-/C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA
+/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=clas12.voms2.opensciencegrid.org
+/C=US/O=Internet2/CN=InCommon RSA IGTF Server CA 3

--- a/vomsdir/eic/eic.voms2.opensciencegrid.org.lsc
+++ b/vomsdir/eic/eic.voms2.opensciencegrid.org.lsc
@@ -1,2 +1,2 @@
-/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=eic.voms2.opensciencegrid.org
-/C=US/O=Internet2/OU=InCommon/CN=InCommon IGTF Server CA
+/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=eic.voms2.opensciencegrid.org
+/C=US/O=Internet2/CN=InCommon RSA IGTF Server CA 3

--- a/vomses
+++ b/vomses
@@ -55,7 +55,7 @@
 "nanohub" "voms.nanohub.org" "15022" "/DC=org/DC=incommon/C=US/ST=IN/L=West Lafayette/O=Purdue University/OU=HUBzero/CN=voms.nanohub.org" "nanohub"
 "sphenix" "hcvoms.sdcc.bnl.gov" "15001" "/DC=org/DC=incommon/C=US/ST=New York/O=Brookhaven National Laboratory/OU=SDCC/CN=hcvoms.sdcc.bnl.gov" "sphenix"
 "clas12" "clas12.voms.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=clas12.voms.opensciencegrid.org" "clas12"
-"clas12" "clas12.voms2.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=clas12.voms2.opensciencegrid.org" "clas12"
+"clas12" "clas12.voms2.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=clas12.voms2.opensciencegrid.org" "clas12"
 "wlcg" "wlcg-voms.cloud.cnaf.infn.it" "15001" "/DC=org/DC=terena/DC=tcs/C=IT/ST=Roma/O=Istituto Nazionale di Fisica Nucleare/CN=wlcg-voms.cloud.cnaf.infn.it" "wlcg"
 "eic" "eic.voms.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=eic.voms.opensciencegrid.org" "eic"
 "eic" "eic.voms2.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=eic.voms2.opensciencegrid.org" "eic"

--- a/vomses
+++ b/vomses
@@ -58,6 +58,6 @@
 "clas12" "clas12.voms2.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=clas12.voms2.opensciencegrid.org" "clas12"
 "wlcg" "wlcg-voms.cloud.cnaf.infn.it" "15001" "/DC=org/DC=terena/DC=tcs/C=IT/ST=Roma/O=Istituto Nazionale di Fisica Nucleare/CN=wlcg-voms.cloud.cnaf.infn.it" "wlcg"
 "eic" "eic.voms.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=eic.voms.opensciencegrid.org" "eic"
-"eic" "eic.voms2.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=eic.voms2.opensciencegrid.org" "eic"
+"eic" "eic.voms2.opensciencegrid.org" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=eic.voms2.opensciencegrid.org" "eic"
 "eic" "eicvoms.sdcc.bnl.gov" "15001" "/DC=org/DC=incommon/C=US/ST=New York/O=Brookhaven National Laboratory/OU=SDCC/CN=eicvoms.sdcc.bnl.gov" "eic"
 "kagra" "voms.cc.kek.jp" "15027" "/C=JP/O=KEK/OU=CRC/CN=host/voms.cc.kek.jp" "kagra"

--- a/vomses
+++ b/vomses
@@ -5,7 +5,7 @@
 "cms" "voms2.cern.ch" "15002" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "cms"
 "cms" "lcg-voms2.cern.ch" "15002" "/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch" "cms"
 "cms" "voms-cms-auth.app.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=cms-auth.web.cern.ch" "cms"
-"GLOW" "voms.chtc.wisc.edu" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/OU=OCIS/CN=voms.chtc.wisc.edu" "GLOW"
+"GLOW" "voms.chtc.wisc.edu" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=voms.chtc.wisc.edu" "GLOW"
 "GLOW" "voms1.chtc.wisc.edu" "15001" "/DC=org/DC=incommon/C=US/ST=Wisconsin/O=University of Wisconsin-Madison/CN=voms1.chtc.wisc.edu" "GLOW"
 "geant4" "voms2.cern.ch" "15007" "/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch" "geant4"
 "geant4" "lcg-voms2.cern.ch" "15007" "/DC=ch/DC=cern/OU=computers/CN=lcg-voms2.cern.ch" "geant4"


### PR DESCRIPTION
Updated the certs for the currently unused CNs ("`voms2`" for EIC/CLAS12, "`voms`" for GLOW). Subjects and issuers have changed.